### PR TITLE
Custom time periods mode and UI

### DIFF
--- a/contents/code/timeCalculations.js
+++ b/contents/code/timeCalculations.js
@@ -140,6 +140,53 @@ function inInterval(currentMinutes, startTime, endTime) {
   }
 }
 
+// --- Custom timing helpers ---
+function parseTimeString(timeStr) {
+  const parts = (timeStr || "00:00").split(":");
+  const h = Math.max(0, Math.min(23, parseInt(parts[0] || 0)));
+  const m = Math.max(0, Math.min(59, parseInt(parts[1] || 0)));
+  return h + m / 60;
+}
+
+function getWallpaperForCustomTime(customTimes, imagePaths) {
+  const currentMinutes = getCurrentTimeMinutes();
+
+  const dawn = timeToMinutes(parseTimeString(customTimes.dawn));
+  const early = timeToMinutes(parseTimeString(customTimes.earlyMorning));
+  const day = timeToMinutes(parseTimeString(customTimes.day));
+  const eve = timeToMinutes(parseTimeString(customTimes.evening));
+  const dusk = timeToMinutes(parseTimeString(customTimes.dusk));
+  const night = timeToMinutes(parseTimeString(customTimes.night));
+
+  if (currentMinutes >= dawn && currentMinutes < early) return imagePaths.dawn;
+  if (currentMinutes >= early && currentMinutes < day)
+    return imagePaths.earlyMorning;
+  if (currentMinutes >= day && currentMinutes < eve) return imagePaths.day;
+  if (currentMinutes >= eve && currentMinutes < dusk) return imagePaths.evening;
+  if (currentMinutes >= dusk && currentMinutes < night) return imagePaths.dusk;
+  return imagePaths.night;
+}
+
+function getNextUpdateTimeCustom(customTimes) {
+  const currentMinutes = getCurrentTimeMinutes();
+  const points = [
+    timeToMinutes(parseTimeString(customTimes.dawn)),
+    timeToMinutes(parseTimeString(customTimes.earlyMorning)),
+    timeToMinutes(parseTimeString(customTimes.day)),
+    timeToMinutes(parseTimeString(customTimes.evening)),
+    timeToMinutes(parseTimeString(customTimes.dusk)),
+    timeToMinutes(parseTimeString(customTimes.night)),
+    24 * 60 + timeToMinutes(parseTimeString(customTimes.dawn)),
+  ];
+
+  for (let i = 0; i < points.length; i++) {
+    if (points[i] > currentMinutes) {
+      return (points[i] - currentMinutes) * 60 * 1000;
+    }
+  }
+  return 60 * 60 * 1000;
+}
+
 function getWallpaperForTime(latitude, longitude, imagePaths) {
   const now = new Date();
   const times = getTwilightTimes(now, latitude, longitude);

--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -5,6 +5,27 @@
   <kcfgfile name="" />
 
   <group name="General">
+    <entry name="TimingMode" type="Int">
+      <default>0</default>
+    </entry>
+    <entry name="DawnTime" type="String">
+      <default>06:00</default>
+    </entry>
+    <entry name="EarlyMorningTime" type="String">
+      <default>07:30</default>
+    </entry>
+    <entry name="DayTime" type="String">
+      <default>09:00</default>
+    </entry>
+    <entry name="EveningTime" type="String">
+      <default>18:00</default>
+    </entry>
+    <entry name="DuskTime" type="String">
+      <default>20:00</default>
+    </entry>
+    <entry name="NightTime" type="String">
+      <default>22:00</default>
+    </entry>
     <entry name="LocationMode" type="Int">
       <default>1</default>
     </entry>

--- a/contents/ui/config.qml
+++ b/contents/ui/config.qml
@@ -20,6 +20,15 @@ ColumnLayout {
     property alias cfg_UpdateInterval: updateIntervalSpinBox.value
     property alias cfg_ShowDebug: debugCheckBox.checked
     property alias cfg_FillMode: fillModeConfig.value
+
+    // Custom timing properties
+    property alias cfg_TimingMode: timingModeConfig.value
+    property alias cfg_DawnTime: dawnTimeConfig.text
+    property alias cfg_EarlyMorningTime: earlyMorningTimeConfig.text
+    property alias cfg_DayTime: dayTimeConfig.text
+    property alias cfg_EveningTime: eveningTimeConfig.text
+    property alias cfg_DuskTime: duskTimeConfig.text
+    property alias cfg_NightTime: nightTimeConfig.text
     
     property alias cfg_DawnImage: dawnImagePath.text
     property alias cfg_EarlyMorningImage: earlyMorningImagePath.text
@@ -37,6 +46,72 @@ ColumnLayout {
     
     Kirigami.FormLayout {
         Layout.fillWidth: true
+        Kirigami.Separator {
+            Kirigami.FormData.label: "Timing Mode"
+            Kirigami.FormData.isSection: true
+        }
+
+        // Hidden config holders
+        QtControls2.SpinBox { id: timingModeConfig; visible: false; value: 0 }
+        QtControls2.TextField { id: dawnTimeConfig; visible: false; text: "06:00" }
+        QtControls2.TextField { id: earlyMorningTimeConfig; visible: false; text: "07:30" }
+        QtControls2.TextField { id: dayTimeConfig; visible: false; text: "09:00" }
+        QtControls2.TextField { id: eveningTimeConfig; visible: false; text: "18:00" }
+        QtControls2.TextField { id: duskTimeConfig; visible: false; text: "20:00" }
+        QtControls2.TextField { id: nightTimeConfig; visible: false; text: "22:00" }
+
+        QtControls2.ButtonGroup { id: timingModeGroup }
+        QtControls2.RadioButton {
+            Kirigami.FormData.label: "Wallpaper timing:";
+            text: "Astronomical (sunrise/sunset)"
+            checked: cfg_TimingMode === 0
+            QtControls2.ButtonGroup.group: timingModeGroup
+            onCheckedChanged: if (checked) cfg_TimingMode = 0
+        }
+        QtControls2.RadioButton {
+            text: "Custom time periods"
+            checked: cfg_TimingMode === 1
+            QtControls2.ButtonGroup.group: timingModeGroup
+            onCheckedChanged: if (checked) cfg_TimingMode = 1
+        }
+
+        // Custom time pickers
+        RowLayout {
+            Kirigami.FormData.label: "Dawn starts at:"; visible: cfg_TimingMode === 1
+            QtControls2.SpinBox { id: dawnH; from: 0; to: 23; value: 6; textFromValue: v=>v.toString().padStart(2,'0'); onValueChanged: dawnTimeConfig.text = `${dawnH.value.toString().padStart(2,'0')}:${dawnM.value.toString().padStart(2,'0')}` }
+            QtControls2.Label { text: ":" }
+            QtControls2.SpinBox { id: dawnM; from: 0; to: 59; value: 0; textFromValue: v=>v.toString().padStart(2,'0'); onValueChanged: dawnTimeConfig.text = `${dawnH.value.toString().padStart(2,'0')}:${dawnM.value.toString().padStart(2,'0')}` }
+        }
+        RowLayout {
+            Kirigami.FormData.label: "Early morning:"; visible: cfg_TimingMode === 1
+            QtControls2.SpinBox { id: earlyH; from: 0; to: 23; value: 7; textFromValue: v=>v.toString().padStart(2,'0'); onValueChanged: earlyMorningTimeConfig.text = `${earlyH.value.toString().padStart(2,'0')}:${earlyM.value.toString().padStart(2,'0')}` }
+            QtControls2.Label { text: ":" }
+            QtControls2.SpinBox { id: earlyM; from: 0; to: 59; value: 30; textFromValue: v=>v.toString().padStart(2,'0'); onValueChanged: earlyMorningTimeConfig.text = `${earlyH.value.toString().padStart(2,'0')}:${earlyM.value.toString().padStart(2,'0')}` }
+        }
+        RowLayout {
+            Kirigami.FormData.label: "Day starts at:"; visible: cfg_TimingMode === 1
+            QtControls2.SpinBox { id: dayH; from: 0; to: 23; value: 9; textFromValue: v=>v.toString().padStart(2,'0'); onValueChanged: dayTimeConfig.text = `${dayH.value.toString().padStart(2,'0')}:${dayM.value.toString().padStart(2,'0')}` }
+            QtControls2.Label { text: ":" }
+            QtControls2.SpinBox { id: dayM; from: 0; to: 59; value: 0; textFromValue: v=>v.toString().padStart(2,'0'); onValueChanged: dayTimeConfig.text = `${dayH.value.toString().padStart(2,'0')}:${dayM.value.toString().padStart(2,'0')}` }
+        }
+        RowLayout {
+            Kirigami.FormData.label: "Evening starts at:"; visible: cfg_TimingMode === 1
+            QtControls2.SpinBox { id: eveH; from: 0; to: 23; value: 18; textFromValue: v=>v.toString().padStart(2,'0'); onValueChanged: eveningTimeConfig.text = `${eveH.value.toString().padStart(2,'0')}:${eveM.value.toString().padStart(2,'0')}` }
+            QtControls2.Label { text: ":" }
+            QtControls2.SpinBox { id: eveM; from: 0; to: 59; value: 0; textFromValue: v=>v.toString().padStart(2,'0'); onValueChanged: eveningTimeConfig.text = `${eveH.value.toString().padStart(2,'0')}:${eveM.value.toString().padStart(2,'0')}` }
+        }
+        RowLayout {
+            Kirigami.FormData.label: "Dusk starts at:"; visible: cfg_TimingMode === 1
+            QtControls2.SpinBox { id: duskH; from: 0; to: 23; value: 20; textFromValue: v=>v.toString().padStart(2,'0'); onValueChanged: duskTimeConfig.text = `${duskH.value.toString().padStart(2,'0')}:${duskM.value.toString().padStart(2,'0')}` }
+            QtControls2.Label { text: ":" }
+            QtControls2.SpinBox { id: duskM; from: 0; to: 59; value: 0; textFromValue: v=>v.toString().padStart(2,'0'); onValueChanged: duskTimeConfig.text = `${duskH.value.toString().padStart(2,'0')}:${duskM.value.toString().padStart(2,'0')}` }
+        }
+        RowLayout {
+            Kirigami.FormData.label: "Night starts at:"; visible: cfg_TimingMode === 1
+            QtControls2.SpinBox { id: nightH; from: 0; to: 23; value: 22; textFromValue: v=>v.toString().padStart(2,'0'); onValueChanged: nightTimeConfig.text = `${nightH.value.toString().padStart(2,'0')}:${nightM.value.toString().padStart(2,'0')}` }
+            QtControls2.Label { text: ":" }
+            QtControls2.SpinBox { id: nightM; from: 0; to: 59; value: 0; textFromValue: v=>v.toString().padStart(2,'0'); onValueChanged: nightTimeConfig.text = `${nightH.value.toString().padStart(2,'0')}:${nightM.value.toString().padStart(2,'0')}` }
+        }
         
         Kirigami.Separator {
             Kirigami.FormData.label: "Wallpaper Images"
@@ -479,6 +554,7 @@ ColumnLayout {
         Kirigami.Separator {
             Kirigami.FormData.label: "Location Settings"
             Kirigami.FormData.isSection: true
+            visible: cfg_TimingMode === 0
         }
         
         QtControls2.ButtonGroup {
@@ -489,6 +565,7 @@ ColumnLayout {
             id: automaticIPLocationRadio
             Kirigami.FormData.label: "Location mode:"
             text: "Automatic (IP-based geolocation)"
+            visible: cfg_TimingMode === 0
             checked: cfg_LocationMode === 0
             QtControls2.ButtonGroup.group: locationModeGroup
             onCheckedChanged: {
@@ -505,6 +582,7 @@ ColumnLayout {
         QtControls2.RadioButton {
             id: automaticTimezoneRadio
             text: "Automatic (timezone estimation)"
+            visible: cfg_TimingMode === 0
             checked: cfg_LocationMode === 2
             QtControls2.ButtonGroup.group: locationModeGroup
             onCheckedChanged: {
@@ -536,14 +614,14 @@ ColumnLayout {
         QtControls2.Button {
             Kirigami.FormData.label: ""
             text: "Detect Location from IP"
-            visible: automaticIPLocationRadio.checked
+            visible: cfg_TimingMode === 0 && automaticIPLocationRadio.checked
             onClicked: detectIPLocation()
         }
         
         QtControls2.Button {
             Kirigami.FormData.label: ""
             text: "Detect Location from Timezone" 
-            visible: automaticTimezoneRadio.checked
+            visible: cfg_TimingMode === 0 && automaticTimezoneRadio.checked
             onClicked: detectTimezoneLocation()
         }
         
@@ -554,7 +632,8 @@ ColumnLayout {
             to: 90000
             stepSize: 1
             value: 40728  // Default: NYC (40.728)
-            enabled: manualLocationRadio.checked
+            enabled: cfg_TimingMode === 0 && manualLocationRadio.checked
+            visible: cfg_TimingMode === 0
             
             property real realValue: value / 1000
             
@@ -567,14 +646,15 @@ ColumnLayout {
             }
         }
         
-        QtControls2.SpinBox {
+    QtControls2.SpinBox {
             id: longitudeSpinBox
             Kirigami.FormData.label: "Longitude:"
             from: -180000
             to: 180000
             stepSize: 1
             value: -74006  // Default: NYC (-74.006)
-            enabled: manualLocationRadio.checked
+            enabled: cfg_TimingMode === 0 && manualLocationRadio.checked
+            visible: cfg_TimingMode === 0
             
             property real realValue: value / 1000
             
@@ -590,6 +670,7 @@ ColumnLayout {
         QtControls2.Label {
             id: locationDisplayLabel
             Kirigami.FormData.label: "Current location:"
+            visible: cfg_TimingMode === 0
             text: {
                 if (automaticLocationRadio.checked) {
                     return `Auto: ${LocationDetection.formatCoordinates(latitudeSpinBox.realValue, longitudeSpinBox.realValue)}`

--- a/contents/ui/config.qml
+++ b/contents/ui/config.qml
@@ -824,13 +824,60 @@ ColumnLayout {
                     const lat = latitudeSpinBox.realValue
                     const lon = longitudeSpinBox.realValue
                     const now = new Date()
-                    
+
                     let info = `Location: ${lat.toFixed(3)}°, ${lon.toFixed(3)}°\n`
                     info += `Current Time: ${now.toLocaleString()}\n\n`
-                    
-                    // Calculate times using TimeCalc
+
+                    if (cfg_TimingMode === 1) {
+                        // Custom time mode
+                        const c = {
+                            dawn: dawnTimeConfig.text || "06:00",
+                            early: earlyMorningTimeConfig.text || "07:30",
+                            day: dayTimeConfig.text || "09:00",
+                            eve: eveningTimeConfig.text || "18:00",
+                            dusk: duskTimeConfig.text || "20:00",
+                            night: nightTimeConfig.text || "22:00"
+                        }
+
+                        info += "Custom Time Periods (HH:MM):\n\n"
+                        info += `🌅 Dawn: ${c.dawn}\n`
+                        info += `🌇 Early Morning: ${c.early}\n`
+                        info += `☀️ Day: ${c.day}\n`
+                        info += `🌆 Evening: ${c.eve}\n`
+                        info += `🌇 Dusk: ${c.dusk}\n`
+                        info += `🌙 Night: ${c.night}\n\n`
+
+                        // Show intervals and current period
+                        function mm(t){ return TimeCalc.timeToMinutes(TimeCalc.parseTimeString(t)) }
+                        const mNow = now.getHours()*60 + now.getMinutes()
+                        const intervals = [
+                            {label:"🌅 Dawn", start:mm(c.dawn), end:mm(c.early)},
+                            {label:"🌇 Early Morning", start:mm(c.early), end:mm(c.day)},
+                            {label:"☀️ Day", start:mm(c.day), end:mm(c.eve)},
+                            {label:"🌆 Evening", start:mm(c.eve), end:mm(c.dusk)},
+                            {label:"🌇 Dusk", start:mm(c.dusk), end:mm(c.night)},
+                            {label:"🌙 Night", start:mm(c.night), end:mm(c.dawn)+24*60}
+                        ]
+                        let currentLabel = ""
+                        for (let i=0;i<intervals.length;i++){
+                            const s = intervals[i].start
+                            const e = intervals[i].end
+                            const within = (s <= e ? (mNow>=s && mNow<e) : (mNow>=s || mNow<e))
+                            if (within && !currentLabel) currentLabel = intervals[i].label
+                        }
+                        info += "Intervals:\n"
+                        info += `${c.dawn} → ${c.early} (Dawn)\n`
+                        info += `${c.early} → ${c.day} (Early Morning)\n`
+                        info += `${c.day} → ${c.eve} (Day)\n`
+                        info += `${c.eve} → ${c.dusk} (Evening)\n`
+                        info += `${c.dusk} → ${c.night} (Dusk)\n`
+                        info += `${c.night} → next ${c.dawn} (Night)\n\n`
+                        if (currentLabel) info += `Current period: ${currentLabel}\n`
+                        return info
+                    }
+
+                    // Astronomical mode
                     const times = TimeCalc.getTwilightTimes(now, lat, lon)
-                    
                     if (times) {
                         info += "Today's Time Periods:\n\n"
                         info += `Astronomical Dawn: ${formatTime(times.astronomicalTwilightSunrise)}\n`
@@ -839,7 +886,7 @@ ColumnLayout {
                         info += `Sunset: ${formatTime(times.sunset)}\n`
                         info += `Civil Dusk: ${formatTime(times.civilTwilightSunset)}\n`
                         info += `Astronomical Dusk: ${formatTime(times.astronomicalTwilightSunset)}\n\n`
-                        
+
                         info += "Wallpaper Periods:\n\n"
                         info += `🌅 Dawn: ${formatTime(times.astronomicalTwilightSunrise)} - ${formatTime(times.civilTwilightSunrise)}\n`
                         info += `🌇 Early Morning: ${formatTime(times.civilTwilightSunrise)} - ${formatTime(times.sunrise + 2)}\n`
@@ -851,7 +898,7 @@ ColumnLayout {
                         info += "Unable to calculate times for this location.\n"
                         info += "You may be in a polar region or the coordinates are invalid."
                     }
-                    
+
                     return info
                 }
                 

--- a/contents/ui/config.qml
+++ b/contents/ui/config.qml
@@ -29,6 +29,9 @@ ColumnLayout {
     property alias cfg_EveningTime: eveningTimeConfig.text
     property alias cfg_DuskTime: duskTimeConfig.text
     property alias cfg_NightTime: nightTimeConfig.text
+
+    // Guard to prevent writebacks during initialization
+    property bool __initializing: true
     
     property alias cfg_DawnImage: dawnImagePath.text
     property alias cfg_EarlyMorningImage: earlyMorningImagePath.text
@@ -66,52 +69,78 @@ ColumnLayout {
             text: "Astronomical (sunrise/sunset)"
             checked: cfg_TimingMode === 0
             QtControls2.ButtonGroup.group: timingModeGroup
-            onCheckedChanged: if (checked) cfg_TimingMode = 0
+            onCheckedChanged: if (checked && !root.__initializing) { cfg_TimingMode = 0; if (configDialog && configDialog.changed) configDialog.changed() }
         }
         QtControls2.RadioButton {
             text: "Custom time periods"
             checked: cfg_TimingMode === 1
             QtControls2.ButtonGroup.group: timingModeGroup
-            onCheckedChanged: if (checked) cfg_TimingMode = 1
+            onCheckedChanged: if (checked && !root.__initializing) { cfg_TimingMode = 1; if (configDialog && configDialog.changed) configDialog.changed() }
         }
 
         // Custom time pickers
         RowLayout {
             Kirigami.FormData.label: "Dawn starts at:"; visible: cfg_TimingMode === 1
-            QtControls2.SpinBox { id: dawnH; from: 0; to: 23; value: 6; textFromValue: v=>v.toString().padStart(2,'0'); onValueChanged: dawnTimeConfig.text = `${dawnH.value.toString().padStart(2,'0')}:${dawnM.value.toString().padStart(2,'0')}` }
+            QtControls2.SpinBox { id: dawnH; from: 0; to: 23; value: 6; textFromValue: v=>v.toString().padStart(2,'0'); onValueChanged: if (!root.__initializing) { dawnTimeConfig.text = `${dawnH.value.toString().padStart(2,'0')}:${dawnM.value.toString().padStart(2,'0')}`; if (configDialog && configDialog.changed) configDialog.changed() } }
             QtControls2.Label { text: ":" }
-            QtControls2.SpinBox { id: dawnM; from: 0; to: 59; value: 0; textFromValue: v=>v.toString().padStart(2,'0'); onValueChanged: dawnTimeConfig.text = `${dawnH.value.toString().padStart(2,'0')}:${dawnM.value.toString().padStart(2,'0')}` }
+            QtControls2.SpinBox { id: dawnM; from: 0; to: 59; value: 0; textFromValue: v=>v.toString().padStart(2,'0'); onValueChanged: if (!root.__initializing) { dawnTimeConfig.text = `${dawnH.value.toString().padStart(2,'0')}:${dawnM.value.toString().padStart(2,'0')}`; if (configDialog && configDialog.changed) configDialog.changed() } }
         }
         RowLayout {
             Kirigami.FormData.label: "Early morning:"; visible: cfg_TimingMode === 1
-            QtControls2.SpinBox { id: earlyH; from: 0; to: 23; value: 7; textFromValue: v=>v.toString().padStart(2,'0'); onValueChanged: earlyMorningTimeConfig.text = `${earlyH.value.toString().padStart(2,'0')}:${earlyM.value.toString().padStart(2,'0')}` }
+            QtControls2.SpinBox { id: earlyH; from: 0; to: 23; value: 7; textFromValue: v=>v.toString().padStart(2,'0'); onValueChanged: if (!root.__initializing) { earlyMorningTimeConfig.text = `${earlyH.value.toString().padStart(2,'0')}:${earlyM.value.toString().padStart(2,'0')}`; if (configDialog && configDialog.changed) configDialog.changed() } }
             QtControls2.Label { text: ":" }
-            QtControls2.SpinBox { id: earlyM; from: 0; to: 59; value: 30; textFromValue: v=>v.toString().padStart(2,'0'); onValueChanged: earlyMorningTimeConfig.text = `${earlyH.value.toString().padStart(2,'0')}:${earlyM.value.toString().padStart(2,'0')}` }
+            QtControls2.SpinBox { id: earlyM; from: 0; to: 59; value: 30; textFromValue: v=>v.toString().padStart(2,'0'); onValueChanged: if (!root.__initializing) { earlyMorningTimeConfig.text = `${earlyH.value.toString().padStart(2,'0')}:${earlyM.value.toString().padStart(2,'0')}`; if (configDialog && configDialog.changed) configDialog.changed() } }
         }
         RowLayout {
             Kirigami.FormData.label: "Day starts at:"; visible: cfg_TimingMode === 1
-            QtControls2.SpinBox { id: dayH; from: 0; to: 23; value: 9; textFromValue: v=>v.toString().padStart(2,'0'); onValueChanged: dayTimeConfig.text = `${dayH.value.toString().padStart(2,'0')}:${dayM.value.toString().padStart(2,'0')}` }
+            QtControls2.SpinBox { id: dayH; from: 0; to: 23; value: 9; textFromValue: v=>v.toString().padStart(2,'0'); onValueChanged: if (!root.__initializing) { dayTimeConfig.text = `${dayH.value.toString().padStart(2,'0')}:${dayM.value.toString().padStart(2,'0')}`; if (configDialog && configDialog.changed) configDialog.changed() } }
             QtControls2.Label { text: ":" }
-            QtControls2.SpinBox { id: dayM; from: 0; to: 59; value: 0; textFromValue: v=>v.toString().padStart(2,'0'); onValueChanged: dayTimeConfig.text = `${dayH.value.toString().padStart(2,'0')}:${dayM.value.toString().padStart(2,'0')}` }
+            QtControls2.SpinBox { id: dayM; from: 0; to: 59; value: 0; textFromValue: v=>v.toString().padStart(2,'0'); onValueChanged: if (!root.__initializing) { dayTimeConfig.text = `${dayH.value.toString().padStart(2,'0')}:${dayM.value.toString().padStart(2,'0')}`; if (configDialog && configDialog.changed) configDialog.changed() } }
         }
         RowLayout {
             Kirigami.FormData.label: "Evening starts at:"; visible: cfg_TimingMode === 1
-            QtControls2.SpinBox { id: eveH; from: 0; to: 23; value: 18; textFromValue: v=>v.toString().padStart(2,'0'); onValueChanged: eveningTimeConfig.text = `${eveH.value.toString().padStart(2,'0')}:${eveM.value.toString().padStart(2,'0')}` }
+            QtControls2.SpinBox { id: eveH; from: 0; to: 23; value: 18; textFromValue: v=>v.toString().padStart(2,'0'); onValueChanged: if (!root.__initializing) { eveningTimeConfig.text = `${eveH.value.toString().padStart(2,'0')}:${eveM.value.toString().padStart(2,'0')}`; if (configDialog && configDialog.changed) configDialog.changed() } }
             QtControls2.Label { text: ":" }
-            QtControls2.SpinBox { id: eveM; from: 0; to: 59; value: 0; textFromValue: v=>v.toString().padStart(2,'0'); onValueChanged: eveningTimeConfig.text = `${eveH.value.toString().padStart(2,'0')}:${eveM.value.toString().padStart(2,'0')}` }
+            QtControls2.SpinBox { id: eveM; from: 0; to: 59; value: 0; textFromValue: v=>v.toString().padStart(2,'0'); onValueChanged: if (!root.__initializing) { eveningTimeConfig.text = `${eveH.value.toString().padStart(2,'0')}:${eveM.value.toString().padStart(2,'0')}`; if (configDialog && configDialog.changed) configDialog.changed() } }
         }
         RowLayout {
             Kirigami.FormData.label: "Dusk starts at:"; visible: cfg_TimingMode === 1
-            QtControls2.SpinBox { id: duskH; from: 0; to: 23; value: 20; textFromValue: v=>v.toString().padStart(2,'0'); onValueChanged: duskTimeConfig.text = `${duskH.value.toString().padStart(2,'0')}:${duskM.value.toString().padStart(2,'0')}` }
+            QtControls2.SpinBox { id: duskH; from: 0; to: 23; value: 20; textFromValue: v=>v.toString().padStart(2,'0'); onValueChanged: if (!root.__initializing) { duskTimeConfig.text = `${duskH.value.toString().padStart(2,'0')}:${duskM.value.toString().padStart(2,'0')}`; if (configDialog && configDialog.changed) configDialog.changed() } }
             QtControls2.Label { text: ":" }
-            QtControls2.SpinBox { id: duskM; from: 0; to: 59; value: 0; textFromValue: v=>v.toString().padStart(2,'0'); onValueChanged: duskTimeConfig.text = `${duskH.value.toString().padStart(2,'0')}:${duskM.value.toString().padStart(2,'0')}` }
+            QtControls2.SpinBox { id: duskM; from: 0; to: 59; value: 0; textFromValue: v=>v.toString().padStart(2,'0'); onValueChanged: if (!root.__initializing) { duskTimeConfig.text = `${duskH.value.toString().padStart(2,'0')}:${duskM.value.toString().padStart(2,'0')}`; if (configDialog && configDialog.changed) configDialog.changed() } }
         }
         RowLayout {
             Kirigami.FormData.label: "Night starts at:"; visible: cfg_TimingMode === 1
-            QtControls2.SpinBox { id: nightH; from: 0; to: 23; value: 22; textFromValue: v=>v.toString().padStart(2,'0'); onValueChanged: nightTimeConfig.text = `${nightH.value.toString().padStart(2,'0')}:${nightM.value.toString().padStart(2,'0')}` }
+            QtControls2.SpinBox { id: nightH; from: 0; to: 23; value: 22; textFromValue: v=>v.toString().padStart(2,'0'); onValueChanged: if (!root.__initializing) { nightTimeConfig.text = `${nightH.value.toString().padStart(2,'0')}:${nightM.value.toString().padStart(2,'0')}`; if (configDialog && configDialog.changed) configDialog.changed() } }
             QtControls2.Label { text: ":" }
-            QtControls2.SpinBox { id: nightM; from: 0; to: 59; value: 0; textFromValue: v=>v.toString().padStart(2,'0'); onValueChanged: nightTimeConfig.text = `${nightH.value.toString().padStart(2,'0')}:${nightM.value.toString().padStart(2,'0')}` }
+            QtControls2.SpinBox { id: nightM; from: 0; to: 59; value: 0; textFromValue: v=>v.toString().padStart(2,'0'); onValueChanged: if (!root.__initializing) { nightTimeConfig.text = `${nightH.value.toString().padStart(2,'0')}:${nightM.value.toString().padStart(2,'0')}`; if (configDialog && configDialog.changed) configDialog.changed() } }
         }
+        
+        // Keep spinboxes in sync when cfg_* text changes (e.g., when loading saved config)
+        Component.onCompleted: {
+            function setFromText(text, hSpin, mSpin) {
+                const parts = (text || "00:00").split(":");
+                const h = Math.max(0, Math.min(23, parseInt(parts[0] || 0)));
+                const m = Math.max(0, Math.min(59, parseInt(parts[1] || 0)));
+                hSpin.value = h; mSpin.value = m;
+            }
+            root.__initializing = true
+            setFromText(dawnTimeConfig.text, dawnH, dawnM)
+            setFromText(earlyMorningTimeConfig.text, earlyH, earlyM)
+            setFromText(dayTimeConfig.text, dayH, dayM)
+            setFromText(eveningTimeConfig.text, eveH, eveM)
+            setFromText(duskTimeConfig.text, duskH, duskM)
+            setFromText(nightTimeConfig.text, nightH, nightM)
+            root.__initializing = false
+        }
+        
+        // Hidden fields react to text changes and update visible spinboxes
+        Connections { target: dawnTimeConfig; function onTextChanged() { root.__initializing = true; const p = dawnTimeConfig.text.split(":"); dawnH.value = parseInt(p[0]||0); dawnM.value = parseInt(p[1]||0); root.__initializing = false } }
+        Connections { target: earlyMorningTimeConfig; function onTextChanged() { root.__initializing = true; const p = earlyMorningTimeConfig.text.split(":"); earlyH.value = parseInt(p[0]||0); earlyM.value = parseInt(p[1]||0); root.__initializing = false } }
+        Connections { target: dayTimeConfig; function onTextChanged() { root.__initializing = true; const p = dayTimeConfig.text.split(":"); dayH.value = parseInt(p[0]||0); dayM.value = parseInt(p[1]||0); root.__initializing = false } }
+        Connections { target: eveningTimeConfig; function onTextChanged() { root.__initializing = true; const p = eveningTimeConfig.text.split(":"); eveH.value = parseInt(p[0]||0); eveM.value = parseInt(p[1]||0); root.__initializing = false } }
+        Connections { target: duskTimeConfig; function onTextChanged() { root.__initializing = true; const p = duskTimeConfig.text.split(":"); duskH.value = parseInt(p[0]||0); duskM.value = parseInt(p[1]||0); root.__initializing = false } }
+        Connections { target: nightTimeConfig; function onTextChanged() { root.__initializing = true; const p = nightTimeConfig.text.split(":"); nightH.value = parseInt(p[0]||0); nightM.value = parseInt(p[1]||0); root.__initializing = false } }
         
         Kirigami.Separator {
             Kirigami.FormData.label: "Wallpaper Images"
@@ -569,7 +598,7 @@ ColumnLayout {
             checked: cfg_LocationMode === 0
             QtControls2.ButtonGroup.group: locationModeGroup
             onCheckedChanged: {
-                if (checked) {
+                if (checked && !root.__initializing) {
                     cfg_LocationMode = 0
                     detectIPLocation()
                 }
@@ -586,7 +615,7 @@ ColumnLayout {
             checked: cfg_LocationMode === 2
             QtControls2.ButtonGroup.group: locationModeGroup
             onCheckedChanged: {
-                if (checked) {
+                if (checked && !root.__initializing) {
                     cfg_LocationMode = 2
                     detectTimezoneLocation()
                 }
@@ -602,7 +631,7 @@ ColumnLayout {
             checked: cfg_LocationMode === 1
             QtControls2.ButtonGroup.group: locationModeGroup
             onCheckedChanged: {
-                if (checked) {
+                if (checked && !root.__initializing) {
                     cfg_LocationMode = 1
                 }
             }

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -25,6 +25,16 @@ WallpaperItem {
     
     // Fill mode configuration
     property int fillModeIndex: wallpaper.configuration.FillMode !== undefined ? wallpaper.configuration.FillMode : 2
+
+    // Timing mode (0=astronomical, 1=custom times)
+    property int timingMode: wallpaper.configuration.TimingMode !== undefined ? wallpaper.configuration.TimingMode : 0
+    // Custom time settings
+    property string dawnTime: wallpaper.configuration.DawnTime || "06:00"
+    property string earlyMorningTime: wallpaper.configuration.EarlyMorningTime || "07:30"
+    property string dayTime: wallpaper.configuration.DayTime || "09:00"
+    property string eveningTime: wallpaper.configuration.EveningTime || "18:00"
+    property string duskTime: wallpaper.configuration.DuskTime || "20:00"
+    property string nightTime: wallpaper.configuration.NightTime || "22:00"
     
     // Watch for changes to the configuration
     Connections {
@@ -33,6 +43,13 @@ WallpaperItem {
             console.log("Dynamic Wallpaper: Configuration FillMode changed to", wallpaper.configuration.FillMode)
             fillModeIndex = wallpaper.configuration.FillMode
         }
+    function onTimingModeChanged() { timingMode = wallpaper.configuration.TimingMode }
+    function onDawnTimeChanged() { dawnTime = wallpaper.configuration.DawnTime }
+    function onEarlyMorningTimeChanged() { earlyMorningTime = wallpaper.configuration.EarlyMorningTime }
+    function onDayTimeChanged() { dayTime = wallpaper.configuration.DayTime }
+    function onEveningTimeChanged() { eveningTime = wallpaper.configuration.EveningTime }
+    function onDuskTimeChanged() { duskTime = wallpaper.configuration.DuskTime }
+    function onNightTimeChanged() { nightTime = wallpaper.configuration.NightTime }
     }
     
     // Convert fill mode index to Image.fillMode value
@@ -158,7 +175,20 @@ WallpaperItem {
             night: nightImage
         }
         
-        const newImage = TimeCalc.getWallpaperForTime(latitude, longitude, imagePaths)
+        let newImage
+        if (timingMode === 1) {
+            const customTimes = {
+                dawn: dawnTime,
+                earlyMorning: earlyMorningTime,
+                day: dayTime,
+                evening: eveningTime,
+                dusk: duskTime,
+                night: nightTime
+            }
+            newImage = TimeCalc.getWallpaperForCustomTime(customTimes, imagePaths)
+        } else {
+            newImage = TimeCalc.getWallpaperForTime(latitude, longitude, imagePaths)
+        }
         
         if (newImage !== currentImage) {
             console.log("Dynamic Wallpaper: Changing to", newImage)
@@ -175,7 +205,20 @@ WallpaperItem {
         }
         
         // Schedule next precise update
-        const nextUpdateMs = TimeCalc.getNextUpdateTime(latitude, longitude)
+        let nextUpdateMs
+        if (timingMode === 1) {
+            const customTimes = {
+                dawn: dawnTime,
+                earlyMorning: earlyMorningTime,
+                day: dayTime,
+                evening: eveningTime,
+                dusk: duskTime,
+                night: nightTime
+            }
+            nextUpdateMs = TimeCalc.getNextUpdateTimeCustom(customTimes)
+        } else {
+            nextUpdateMs = TimeCalc.getNextUpdateTime(latitude, longitude)
+        }
         if (nextUpdateMs < updateTimer.interval) {
             preciseTimer.interval = nextUpdateMs
             preciseTimer.start()


### PR DESCRIPTION
This PR implements custom time periods alongside astronomical timing, with UI and persistence improvements.

Highlights:
- Adds Timing Mode (Astronomical vs Custom)
- Six configurable period times with defaults (Dawn, Early Morning, Day, Evening, Dusk, Night)
- Location settings hidden in Custom mode; moved under Timing Mode section
- Show Time Periods dialog reflects selected mode with intervals/current period
- Minor UI and persistence refinements

Closes #1.
